### PR TITLE
Initial port to 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = 'mc1.18_v0.6'
+version = 'mc1.18.2_v0.7'
 group = 'com.simibubi.mightyarchitect' 
 archivesBaseName = 'mightyarchitect'
 
@@ -34,7 +34,7 @@ repositories {
 }
 
 minecraft {
-    mappings channel: 'official', version: '1.18'
+    mappings channel: 'official', version: '1.18.2'
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
     
     runs {
@@ -73,7 +73,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.18-38.0.15'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
 }
 
 jar {

--- a/src/main/java/com/simibubi/mightyarchitect/control/TemplateBlockAccess.java
+++ b/src/main/java/com/simibubi/mightyarchitect/control/TemplateBlockAccess.java
@@ -11,6 +11,7 @@ import java.util.function.Predicate;
 import com.simibubi.mightyarchitect.control.compose.Cuboid;
 import com.simibubi.mightyarchitect.foundation.WrappedWorld;
 
+import net.minecraft.core.Holder;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
@@ -85,9 +86,9 @@ public class TemplateBlockAccess extends WrappedWorld {
 	}
 
 	@Override
-	public Biome getBiome(BlockPos pos) {
+	public Holder<Biome> getBiome(BlockPos pos) {
 		return registryAccess().registryOrThrow(Registry.BIOME_REGISTRY)
-			.get(Biomes.THE_VOID);
+			.getOrCreateHolder(Biomes.THE_VOID);
 	}
 
 	@Override

--- a/src/main/java/com/simibubi/mightyarchitect/foundation/WrappedWorld.java
+++ b/src/main/java/com/simibubi/mightyarchitect/foundation/WrappedWorld.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.core.Holder;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Entity;
@@ -19,7 +20,6 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.scores.Scoreboard;
-import net.minecraft.tags.TagContainer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundSource;
@@ -72,7 +72,7 @@ public class WrappedWorld extends Level {
 	};
 
 	public WrappedWorld(Level world) {
-		super((WritableLevelData) world.getLevelData(), world.dimension(), world.dimensionType(),
+		super((WritableLevelData) world.getLevelData(), world.dimension(), world.dimensionTypeRegistration(),
 			() -> world.getProfiler(), world.isClientSide, false, 0);
 		this.world = world;
 	}
@@ -181,7 +181,7 @@ public class WrappedWorld extends Level {
 	}
 
 	@Override
-	public Biome getUncachedNoiseBiome(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
+	public Holder<Biome> getUncachedNoiseBiome(int p_225604_1_, int p_225604_2_, int p_225604_3_) {
 		return world.getUncachedNoiseBiome(p_225604_1_, p_225604_2_, p_225604_3_);
 	}
 
@@ -198,11 +198,6 @@ public class WrappedWorld extends Level {
 	@Override
 	public float getShade(Direction p_230487_1_, boolean p_230487_2_) {
 		return 1;
-	}
-
-	@Override
-	public TagContainer getTagManager() {
-		return world.getTagManager();
 	}
 
 	@Override

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,11 +1,11 @@
 modLoader="javafml" 
-loaderVersion="[36,)"
+loaderVersion="[40,)"
 #issueTrackerURL=""
 license="MIT"
 
 [[mods]] 
 modId="mightyarchitect"
-version="0.5"
+version="0.7"
 displayName="The Mighty Architect" 
 #updateJSONURL=""
 authors="simibubi" 
@@ -14,20 +14,20 @@ description='''Design elaborate buildings within a minute! [G] is the default ke
 [[dependencies.mightyarchitect]] 
     modId="forge"
     mandatory=true 
-    versionRange="[36,)"
+    versionRange="[40,)"
     ordering="NONE"
     side="CLIENT"
 	
 [[dependencies.mightyarchitect]] 
     modId="forge"
     mandatory=true 
-    versionRange="[36,)"
+    versionRange="[40,)"
     ordering="NONE"
     side="SERVER"
 
 [[dependencies.mightyarchitect]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.5,)"
+    versionRange="[1.18.2]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
This should simply be a non-breaking port to be comptible with 1.18.2

The only thing that really changed was biome access now going through Holder<Biome> instead of Biome instances directly.

This still needs testing. I will give an update once this is properly tested.